### PR TITLE
Include the repository field

### DIFF
--- a/nate-engine-core/Cargo.toml
+++ b/nate-engine-core/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Nathaniel Wert <n8.wert.b@gmail.com>"]
 description = "Core Code for a game engine I created just for fun"
 readme = "../README.md"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/N8BWert/nengine"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.